### PR TITLE
AnyObject name patch

### DIFF
--- a/src/pikara/analysis.py
+++ b/src/pikara/analysis.py
@@ -236,7 +236,7 @@ def _parse(pickle):
     def get_global_stack_object(arg, objtype=object):
         if arg not in global_objects:
             global_objects[arg] = StackObject(name=arg, obtype=objtype,
-                                              doc="Object of type {typname}.".format(typname=arg))
+                                              doc="Object of type {typename}.".format(typename=arg))
         return global_objects[arg]
 
     def _raise(E, msg, **kwargs):

--- a/src/pikara/analysis.py
+++ b/src/pikara/analysis.py
@@ -181,7 +181,7 @@ class _ParseResult(object):
     maxproto = attr.ib()
     stack = attr.ib()
     memo = attr.ib()
-    global_objects = attr.ib(default=set())
+    global_objects = attr.ib(default=set)
 
 
 @attr.s

--- a/src/pikara/analysis.py
+++ b/src/pikara/analysis.py
@@ -1,5 +1,5 @@
 import pickletools
-from pickletools import markobject, StackObject
+from pickletools import StackObject, markobject
 
 import attr
 from six import next
@@ -181,7 +181,7 @@ class _ParseResult(object):
     maxproto = attr.ib()
     stack = attr.ib()
     memo = attr.ib()
-    global_objects = attr.ib(default=set)
+    global_objects = attr.ib(default=dict)
 
 
 @attr.s

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -128,34 +128,7 @@ def test_nested_list():
     assert expected.memo == actual.memo
 
 
-class NullReduce():
-    def __reduce__(self):
-        return NullReduce, ()
-
-
-def test_reduce():
-    expected = _ParseResult(
-        parsed=[
-            _ParseEntry(op=PROTO, arg=3, pos=0, stackslice=None),
-            _ParseEntry(op=GLOBAL, arg='tests.test_parse NullReduce', pos=2, stackslice=None),
-            _ParseEntry(op=BINPUT, arg=0, pos=31, stackslice=None),
-            _ParseEntry(op=EMPTY_TUPLE, arg=None, pos=33, stackslice=None),
-            _ParseEntry(op=REDUCE, arg=None, pos=34, stackslice=[anyobject, pytuple]),
-            _ParseEntry(op=BINPUT, arg=1, pos=35, stackslice=None),
-            _ParseEntry(op=STOP, arg=None, pos=37, stackslice=[[anyobject, pytuple]])
-        ],
-        maxproto=2,
-        stack=[],
-        memo={0: anyobject, 1: [anyobject, pytuple]}
-    )
-    actual = _parse(dumps(NullReduce(), protocol=3))
-    assert expected.parsed == actual.parsed
-    assert expected.maxproto == actual.maxproto
-    assert expected.stack == actual.stack
-    assert expected.memo == actual.memo
-
-
-class NullReduce():
+class NullReduce(object):
     def __reduce__(self):
         return NullReduce, ()
 
@@ -185,7 +158,7 @@ def test_reduce():
     assert expected.memo == actual.memo
 
 
-class ReduceSentinel():
+class ReduceSentinel(object):
     def __init__(self, s):
         self.s = s
 
@@ -293,38 +266,7 @@ def test_reduce_sentinel_list():
     assert expected.memo == actual.memo
 
 
-class NullReduceEx():
-    def __reduce_ex__(self, protocol):
-        return NullReduceEx, ()
-
-
-def test_reduce_ex():
-    actual = _parse(dumps(NullReduceEx(), protocol=3))
-    expected = _ParseResult(
-        parsed=[
-            _ParseEntry(op=PROTO, arg=3, pos=0, stackslice=None),
-            _ParseEntry(op=GLOBAL, arg='tests.test_parse NullReduceEx', pos=2, stackslice=None),
-            _ParseEntry(op=BINPUT, arg=0, pos=33, stackslice=None),
-            _ParseEntry(op=EMPTY_TUPLE, arg=None, pos=35, stackslice=None),
-            _ParseEntry(op=REDUCE, arg=None, pos=36,
-                        stackslice=[actual.global_objects['tests.test_parse NullReduceEx'], pytuple]),
-            _ParseEntry(op=BINPUT, arg=1, pos=37, stackslice=None),
-            _ParseEntry(op=STOP, arg=None, pos=39,
-                        stackslice=[[actual.global_objects['tests.test_parse NullReduceEx'], pytuple]])
-        ],
-        maxproto=2,
-        stack=[],
-        memo={0: actual.global_objects['tests.test_parse NullReduceEx'],
-              1: [actual.global_objects['tests.test_parse NullReduceEx'],
-                  pytuple]}
-    )
-    assert expected.parsed == actual.parsed
-    assert expected.maxproto == actual.maxproto
-    assert expected.stack == actual.stack
-    assert expected.memo == actual.memo
-
-
-class NullReduceEx():
+class NullReduceEx(object):
     def __reduce_ex__(self, protocol):
         return NullReduceEx, ()
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,11 +1,10 @@
 import pickletools
 from pickle import dumps
-from pickletools import (anyobject, markobject, pyint, pylist, pytuple,
+from pickletools import (anyobject, markobject, pyint, pylist, pytuple, pybool, pynone,
                          pyunicode)
 
 import attr
 
-from pikara.analysis import _parse, _ParseEntry, _ParseResult, global_objects
 from pikara.analysis import _parse, _ParseEntry, _ParseResult
 
 for opcode in pickletools.opcodes:
@@ -170,15 +169,15 @@ def test_reduce():
             _ParseEntry(op=BINPUT, arg=0, pos=31, stackslice=None),
             _ParseEntry(op=EMPTY_TUPLE, arg=None, pos=33, stackslice=None),
             _ParseEntry(op=REDUCE, arg=None, pos=34,
-                        stackslice=[global_objects['tests.test_parse NullReduce'], pytuple]),
+                        stackslice=[actual.global_objects['tests.test_parse NullReduce'], pytuple]),
             _ParseEntry(op=BINPUT, arg=1, pos=35, stackslice=None),
             _ParseEntry(op=STOP, arg=None, pos=37,
-                        stackslice=[[global_objects['tests.test_parse NullReduce'], pytuple]])
+                        stackslice=[[actual.global_objects['tests.test_parse NullReduce'], pytuple]])
         ],
         maxproto=2,
         stack=[],
-        memo={0: global_objects['tests.test_parse NullReduce'],
-              1: [global_objects['tests.test_parse NullReduce'], pytuple]}
+        memo={0: actual.global_objects['tests.test_parse NullReduce'],
+              1: [actual.global_objects['tests.test_parse NullReduce'], pytuple]}
     )
     assert expected.parsed == actual.parsed
     assert expected.maxproto == actual.maxproto
@@ -203,19 +202,23 @@ def test_reduce_sentinel():
             _ParseEntry(op=BINPUT, arg=0, pos=35, stackslice=None),
             _ParseEntry(op=GLOBAL, arg='builtins Ellipsis', pos=37, stackslice=None),
             _ParseEntry(op=BINPUT, arg=1, pos=56, stackslice=None),
-            _ParseEntry(op=TUPLE1, arg=None, pos=58, stackslice=[global_objects['builtins Ellipsis']]),
+            _ParseEntry(op=TUPLE1, arg=None, pos=58, stackslice=[actual.global_objects['builtins Ellipsis']]),
             _ParseEntry(op=BINPUT, arg=2, pos=59, stackslice=None),
-            _ParseEntry(op=REDUCE, arg=None, pos=61, stackslice=[global_objects['tests.test_parse ReduceSentinel'],
-                                                                 [global_objects['builtins Ellipsis']]]),
+            _ParseEntry(op=REDUCE, arg=None, pos=61, stackslice=[
+                actual.global_objects['tests.test_parse ReduceSentinel'],
+                [actual.global_objects['builtins Ellipsis']]]),
             _ParseEntry(op=BINPUT, arg=3, pos=62, stackslice=None),
             _ParseEntry(op=STOP, arg=None, pos=64, stackslice=[
-                [global_objects['tests.test_parse ReduceSentinel'], [global_objects['builtins Ellipsis']]]])
+                [actual.global_objects['tests.test_parse ReduceSentinel'], [
+                    actual.global_objects['builtins Ellipsis']]]])
         ],
         maxproto=2,
         stack=[],
-        memo={0: global_objects['tests.test_parse ReduceSentinel'], 1: global_objects['builtins Ellipsis'],
-              2: [global_objects['builtins Ellipsis']],
-              3: [global_objects['tests.test_parse ReduceSentinel'], [global_objects['builtins Ellipsis']]]}
+        memo={0: actual.global_objects['tests.test_parse ReduceSentinel'],
+              1: actual.global_objects['builtins Ellipsis'],
+              2: [actual.global_objects['builtins Ellipsis']],
+              3: [actual.global_objects['tests.test_parse ReduceSentinel'], [
+                  actual.global_objects['builtins Ellipsis']]]}
     )
     assert expected.parsed == actual.parsed
     assert expected.maxproto == actual.maxproto
@@ -228,21 +231,61 @@ def test_reduce_sentinel_list():
     expected = _ParseResult(
         parsed=[
             _ParseEntry(op=PROTO, arg=3, pos=0, stackslice=None),
-            _ParseEntry(op=GLOBAL, arg='tests.test_parse ReduceSentinel', pos=2, stackslice=None),
-            _ParseEntry(op=BINPUT, arg=0, pos=35, stackslice=None),
-            _ParseEntry(op=GLOBAL, arg='builtins Ellipsis', pos=37, stackslice=None),
-            _ParseEntry(op=BINPUT, arg=1, pos=56, stackslice=None),
-            _ParseEntry(op=TUPLE1, arg=None, pos=58, stackslice=[anyobject]),
-            _ParseEntry(op=BINPUT, arg=2, pos=59, stackslice=None),
-            _ParseEntry(op=REDUCE, arg=None, pos=61, stackslice=[anyobject, [anyobject]]),
-            _ParseEntry(op=BINPUT, arg=3, pos=62, stackslice=None),
-            _ParseEntry(op=STOP, arg=None, pos=64, stackslice=[[anyobject, [anyobject]]])
+            _ParseEntry(op=EMPTY_LIST, arg=None, pos=2, stackslice=None),
+            _ParseEntry(op=BINPUT, arg=0, pos=3, stackslice=None),
+            _ParseEntry(op=MARK, arg=None, pos=5, stackslice=None),
+            _ParseEntry(op=GLOBAL, arg='tests.test_parse ReduceSentinel', pos=6, stackslice=None),
+            _ParseEntry(op=BINPUT, arg=1, pos=39, stackslice=None),
+            _ParseEntry(op=GLOBAL, arg='builtins Ellipsis', pos=41, stackslice=None),
+            _ParseEntry(op=BINPUT, arg=2, pos=60, stackslice=None),
+            _ParseEntry(op=TUPLE1, arg=None, pos=62, stackslice=[actual.global_objects['builtins Ellipsis']]),
+            _ParseEntry(op=BINPUT, arg=3, pos=63, stackslice=None),
+            _ParseEntry(op=REDUCE, arg=None, pos=65,
+                        stackslice=[actual.global_objects['tests.test_parse ReduceSentinel'],
+                                    [actual.global_objects['builtins Ellipsis']]]),
+            _ParseEntry(op=BINPUT, arg=4, pos=66, stackslice=None),
+            _ParseEntry(op=BINGET, arg=1, pos=68, stackslice=None),
+            _ParseEntry(op=NEWTRUE, arg=None, pos=70, stackslice=None),
+            _ParseEntry(op=TUPLE1, arg=None, pos=71, stackslice=[pybool]),
+            _ParseEntry(op=BINPUT, arg=5, pos=72, stackslice=None),
+            _ParseEntry(op=REDUCE, arg=None, pos=74,
+                        stackslice=[actual.global_objects['tests.test_parse ReduceSentinel'],
+                                    [pybool]]),
+
+            _ParseEntry(op=BINPUT, arg=6, pos=75, stackslice=None),
+            _ParseEntry(op=BINGET, arg=1, pos=77, stackslice=None),
+            _ParseEntry(op=NONE, arg=None, pos=79, stackslice=None),
+            _ParseEntry(op=TUPLE1, arg=None, pos=80, stackslice=[pynone]),
+            _ParseEntry(op=BINPUT, arg=7, pos=81, stackslice=None),
+            _ParseEntry(op=REDUCE, arg=None, pos=83,
+                        stackslice=[actual.global_objects['tests.test_parse ReduceSentinel'],
+                                    [pynone]]),
+            _ParseEntry(op=BINPUT, arg=8, pos=84, stackslice=None),
+            _ParseEntry(op=APPENDS, arg=None, pos=86,
+                        stackslice=[pylist, markobject, [[actual.global_objects['tests.test_parse ReduceSentinel'],
+                                                          [actual.global_objects['builtins Ellipsis']]],
+                                                         [actual.global_objects['tests.test_parse ReduceSentinel'],
+                                                          [pybool]],
+                                                         [actual.global_objects['tests.test_parse ReduceSentinel'],
+                                                          [pynone]]]]),
+            _ParseEntry(op=STOP, arg=None, pos=87,
+                        stackslice=[[pylist, markobject, [[actual.global_objects['tests.test_parse ReduceSentinel'],
+                                                           [actual.global_objects['builtins Ellipsis']]],
+                                                          [actual.global_objects['tests.test_parse ReduceSentinel'],
+                                                           [pybool]],
+                                                          [actual.global_objects['tests.test_parse ReduceSentinel'],
+                                                           [pynone]]]]])
         ],
         maxproto=2,
         stack=[],
-        memo={0: global_objects['tests.test_parse ReduceSentinel'], 1: global_objects['builtins Ellipsis'],
-              2: [global_objects['builtins Ellipsis']],
-              3: [global_objects['tests.test_parse ReduceSentinel'], [global_objects['builtins Ellipsis']]]}
+        memo={0: pylist, 1: actual.global_objects['tests.test_parse ReduceSentinel'],
+              2: actual.global_objects['builtins Ellipsis'],
+              3: [actual.global_objects['builtins Ellipsis']],
+              4: [actual.global_objects['tests.test_parse ReduceSentinel'], [
+                  actual.global_objects['builtins Ellipsis']]], 5: [pybool],
+              6: [actual.global_objects['tests.test_parse ReduceSentinel'], [
+                  pybool]], 7: [pynone], 8: [actual.global_objects['tests.test_parse ReduceSentinel'], [
+                pynone]]}
     )
     assert expected.parsed == actual.parsed
     assert expected.maxproto == actual.maxproto
@@ -264,15 +307,16 @@ def test_reduce_ex():
             _ParseEntry(op=BINPUT, arg=0, pos=33, stackslice=None),
             _ParseEntry(op=EMPTY_TUPLE, arg=None, pos=35, stackslice=None),
             _ParseEntry(op=REDUCE, arg=None, pos=36,
-                        stackslice=[global_objects['tests.test_parse NullReduceEx'], pytuple]),
+                        stackslice=[actual.global_objects['tests.test_parse NullReduceEx'], pytuple]),
             _ParseEntry(op=BINPUT, arg=1, pos=37, stackslice=None),
             _ParseEntry(op=STOP, arg=None, pos=39,
-                        stackslice=[[global_objects['tests.test_parse NullReduceEx'], pytuple]])
+                        stackslice=[[actual.global_objects['tests.test_parse NullReduceEx'], pytuple]])
         ],
         maxproto=2,
         stack=[],
-        memo={0: global_objects['tests.test_parse NullReduceEx'],
-              1: [global_objects['tests.test_parse NullReduceEx'], pytuple]}
+        memo={0: actual.global_objects['tests.test_parse NullReduceEx'],
+              1: [actual.global_objects['tests.test_parse NullReduceEx'],
+                  pytuple]}
     )
     assert expected.parsed == actual.parsed
     assert expected.maxproto == actual.maxproto
@@ -294,15 +338,16 @@ def test_reduce_ex():
             _ParseEntry(op=BINPUT, arg=0, pos=33, stackslice=None),
             _ParseEntry(op=EMPTY_TUPLE, arg=None, pos=35, stackslice=None),
             _ParseEntry(op=REDUCE, arg=None, pos=36,
-                        stackslice=[global_objects['tests.test_parse NullReduceEx'], pytuple]),
+                        stackslice=[actual.global_objects['tests.test_parse NullReduceEx'], pytuple]),
             _ParseEntry(op=BINPUT, arg=1, pos=37, stackslice=None),
             _ParseEntry(op=STOP, arg=None, pos=39,
-                        stackslice=[[global_objects['tests.test_parse NullReduceEx'], pytuple]])
+                        stackslice=[[actual.global_objects['tests.test_parse NullReduceEx'], pytuple]])
         ],
         maxproto=2,
         stack=[],
-        memo={0: global_objects['tests.test_parse NullReduceEx'],
-              1: [global_objects['tests.test_parse NullReduceEx'], pytuple]}
+        memo={0: actual.global_objects['tests.test_parse NullReduceEx'],
+              1: [actual.global_objects['tests.test_parse NullReduceEx'],
+                  pytuple]}
     )
     assert expected.parsed == actual.parsed
     assert expected.maxproto == actual.maxproto


### PR DESCRIPTION
This is part one, for now we are just gathering the names of the globals and not cleanly gathering the signature used.

test_reduce_sentinel_list is incomplete and broken in this commit